### PR TITLE
Correctly modify returnExternal in case of Array.

### DIFF
--- a/src/Resource.ts
+++ b/src/Resource.ts
@@ -569,7 +569,7 @@ export class Resource {
 
                 if (filter(resp)) {
 
-                  this.$_setDataToObject(shell.returnExternal, map(resp));
+                  shell.returnExternal = this.$_setDataToObject(shell.returnExternal, map(resp));
 
                 }
 


### PR DESCRIPTION
For the moment in case of an array, `shell.returnExternal` isn't modified.