### PR TITLE
Let ResourceAction onError fire for get requests

### DIFF
--- a/src/ResourceAction.ts
+++ b/src/ResourceAction.ts
@@ -21,9 +21,19 @@ export function ResourceAction(methodOptions?: ResourceActionBase) {
     (<any>target)[propertyKey] = function (...args: any[]): ResourceResult<any> | ResourceModel<Resource> {
 
       let data = args.length ? args[0] : null;
-      let params = args.length > 1 ? args[1] : null;
-      let callback = args.length > 2 ? args[2] : null;
-      let onError = args.length > 3 ? args[3] : null;
+      let params;
+      let callback;
+      let onError;
+
+      if(methodOptions.method == RequestMethod.Get) {
+        params = args.length > 0 ? args[0] : null;
+        callback = args.length > 1 ? args[1] : null;
+        onError = args.length > 2 ? args[2] : null;
+      } else {
+        params = args.length > 1 ? args[1] : null;
+        callback = args.length > 2 ? args[2] : null;
+        onError = args.length > 3 ? args[3] : null;
+      }
 
       if (typeof data === 'function') {
         callback = data;


### PR DESCRIPTION
Check if we're doing a GET or if we're doing something else, so we wind up with the right number of args to be able to call onError for get requests